### PR TITLE
ci: fix version updating and PyPI publishing process

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -74,7 +76,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@v1.9.0
         with:
           user: ${{ secrets.PYPI_PASSWORD }}
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -64,3 +64,8 @@ fi
 
 # Set the output variable for the new version
 echo "::set-output name=NEW_VERSION::v$NEW_VERSION"
+
+# Commit the version bump
+git add setup.py
+git commit -m "Bump version to $NEW_VERSION"
+git push origin main

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,25 @@
 from setuptools import setup, find_packages
 import pathlib
+import subprocess
 
 here = pathlib.Path(__file__).parent.resolve()
 
+def get_version():
+    try:
+        version = subprocess.check_output(['git', 'describe', '--tags']).decode().strip()
+        return version.lstrip('v')
+    except:
+        return '0.0.0'
+
 setup(
     name="code-collator",
-    version="0.1",
+    version=get_version(),
     description="A CLI tool to aggregate codebase into a single Markdown file",
     long_description=(here / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',
     url="https://github.com/tawanda-kembo/code-collator",
     author="Tawanda Kembo",
-    author_email="tkembo@gmail.com",
+    author_email="tawanda@mrkembo.com",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
- Update bump_version.sh to modify setup.py
- Ensure PyPI publishing job uses latest code version
- Fix issue with duplicate version uploads to PyPI

This change ensures that each release has a unique version number in both git tags and the Python package, allowing successful uploads to PyPI.